### PR TITLE
Predecessor

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "plusnew-webpack-config": "0.5.94",
     "tslint": "5.8.0",
     "tslint-config-airbnb": "5.4.2",
-    "typescript": "2.8.1"
+    "typescript": "2.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plusnew",
-  "version": "0.5.97",
-  "description": "ts framework with an typesecure and functional approach",
+  "version": "0.5.101",
+  "description": "ts component framework with an typesecure and functional approach",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/plusnew/plusnew#readme",
   "dependencies": {
-    "redchain": "0.5.73"
+    "redchain": "0.5.101"
   },
   "devDependencies": {
     "concurrently": "3.5.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ class Plusnew {
    */
   public render(element: PlusnewAbstractElement, containerElement: HTMLElement, options?: renderOptions) {
     // Fake RootInstance
-    const wrapper = new RootInstance(true, undefined, () => 0, options);
+    const wrapper = new RootInstance(true, undefined, () => null, options);
 
     wrapper.ref = containerElement;
 
@@ -32,7 +32,7 @@ class Plusnew {
       containerElement.removeChild(containerElement.childNodes[0]);
     }
 
-    return factory(element, wrapper, () => 0);
+    return factory(element, wrapper, () => null);
   }
 
   Fragment = Fragment;

--- a/src/instances/factory.ts
+++ b/src/instances/factory.ts
@@ -1,5 +1,5 @@
 import { ApplicationElement } from '../interfaces/component';
-import Instance, { getSuccessor } from './types/Instance';
+import Instance, { getPredeccessor } from './types/Instance';
 import ArrayInstance from './types/Array/Instance';
 import PlaceHolderInstance from './types/Placeholder/Instance';
 import DomInstance from './types/Dom/Instance';
@@ -17,41 +17,41 @@ import types from './types/types';
 export default function (
   abstractElement: ApplicationElement,
   parentInstance: Instance,
-  getSuccessor: getSuccessor,
+  getPredecessor: getPredeccessor,
 ): Instance {
   // @TODO add something for invalid functions
   if (elementTypeChecker.isPlaceholderElement(abstractElement) === true) {
-    return new PlaceHolderInstance(abstractElement as false, parentInstance, getSuccessor);
+    return new PlaceHolderInstance(abstractElement as false, parentInstance, getPredecessor);
   }
   if (elementTypeChecker.isTextElement(abstractElement) === true) {
-    return new TextInstance(abstractElement as string, parentInstance, getSuccessor);
+    return new TextInstance(abstractElement as string, parentInstance, getPredecessor);
   }
   if (elementTypeChecker.isArrayElement(abstractElement) === true) {
     return new ArrayInstance(
       abstractElement as (PlusnewAbstractElement)[],
       parentInstance,
-      getSuccessor,
+      getPredecessor,
     );
   }
   if (elementTypeChecker.isFragmentElement(abstractElement) === true) {
-    return new FragmentInstance(abstractElement as PlusnewAbstractElement, parentInstance, getSuccessor);
+    return new FragmentInstance(abstractElement as PlusnewAbstractElement, parentInstance, getPredecessor);
   }
   if (elementTypeChecker.isDomElement(abstractElement) === true) {
-    return new DomInstance(abstractElement as PlusnewAbstractElement, parentInstance, getSuccessor);
+    return new DomInstance(abstractElement as PlusnewAbstractElement, parentInstance, getPredecessor);
   }
   if (elementTypeChecker.isComponentElement(abstractElement)) {
     if (parentInstance.createChildrenComponents === false && parentInstance.nodeType !== types.Root) {
       return new ShallowInstance(
         abstractElement as PlusnewAbstractElement,
         parentInstance,
-        getSuccessor,
+        getPredecessor,
       );
     }
 
     return new ComponentInstance(
       abstractElement as PlusnewAbstractElement,
       parentInstance,
-      getSuccessor,
+      getPredecessor,
     );
   }
 

--- a/src/instances/factory.ts
+++ b/src/instances/factory.ts
@@ -1,5 +1,5 @@
 import { ApplicationElement } from '../interfaces/component';
-import Instance from './types/Instance';
+import Instance, { getSuccessor } from './types/Instance';
 import ArrayInstance from './types/Array/Instance';
 import PlaceHolderInstance from './types/Placeholder/Instance';
 import DomInstance from './types/Dom/Instance';
@@ -17,41 +17,41 @@ import types from './types/types';
 export default function (
   abstractElement: ApplicationElement,
   parentInstance: Instance,
-  previousAbstractSiblingCount: () => number,
+  getSuccessor: getSuccessor,
 ): Instance {
   // @TODO add something for invalid functions
   if (elementTypeChecker.isPlaceholderElement(abstractElement) === true) {
-    return new PlaceHolderInstance(abstractElement as false, parentInstance, previousAbstractSiblingCount);
+    return new PlaceHolderInstance(abstractElement as false, parentInstance, getSuccessor);
   }
   if (elementTypeChecker.isTextElement(abstractElement) === true) {
-    return new TextInstance(abstractElement as string, parentInstance, previousAbstractSiblingCount);
+    return new TextInstance(abstractElement as string, parentInstance, getSuccessor);
   }
   if (elementTypeChecker.isArrayElement(abstractElement) === true) {
     return new ArrayInstance(
       abstractElement as (PlusnewAbstractElement)[],
       parentInstance,
-      previousAbstractSiblingCount,
+      getSuccessor,
     );
   }
   if (elementTypeChecker.isFragmentElement(abstractElement) === true) {
-    return new FragmentInstance(abstractElement as PlusnewAbstractElement, parentInstance, previousAbstractSiblingCount);
+    return new FragmentInstance(abstractElement as PlusnewAbstractElement, parentInstance, getSuccessor);
   }
   if (elementTypeChecker.isDomElement(abstractElement) === true) {
-    return new DomInstance(abstractElement as PlusnewAbstractElement, parentInstance, previousAbstractSiblingCount);
+    return new DomInstance(abstractElement as PlusnewAbstractElement, parentInstance, getSuccessor);
   }
   if (elementTypeChecker.isComponentElement(abstractElement)) {
     if (parentInstance.createChildrenComponents === false && parentInstance.nodeType !== types.Root) {
       return new ShallowInstance(
         abstractElement as PlusnewAbstractElement,
         parentInstance,
-        previousAbstractSiblingCount,
+        getSuccessor,
       );
     }
 
     return new ComponentInstance(
       abstractElement as PlusnewAbstractElement,
       parentInstance,
-      previousAbstractSiblingCount,
+      getSuccessor,
     );
   }
 

--- a/src/instances/reconciler.ts
+++ b/src/instances/reconciler.ts
@@ -18,7 +18,7 @@ export class Reconciler {
       return instance;
     }
 
-    return factory(newAbstractElement, instance.parentInstance as Instance, instance.getSuccessor);
+    return factory(newAbstractElement, instance.parentInstance as Instance, instance.getPredecessor);
   }
 
   /**

--- a/src/instances/reconciler.ts
+++ b/src/instances/reconciler.ts
@@ -18,7 +18,7 @@ export class Reconciler {
       return instance;
     }
 
-    return factory(newAbstractElement, instance.parentInstance as Instance, instance.previousAbstractSiblingCount);
+    return factory(newAbstractElement, instance.parentInstance as Instance, instance.getSuccessor);
   }
 
   /**

--- a/src/instances/types/Array/Instance.ts
+++ b/src/instances/types/Array/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance from '../Instance';
+import Instance, { getSuccessor } from '../Instance';
 import ChildrenInstance from '../ChildrenInstance';
 import PlusnewAbstractElement from '../../../PlusnewAbstractElement';
 import reconcile from './reconcile';
@@ -12,22 +12,19 @@ export default class ArrayInstance extends ChildrenInstance {
   constructor(
     abstractElements: (PlusnewAbstractElement)[],
     parentInstance: Instance,
-    previousAbstractSiblingCount: () => number,
+    getSuccessor: getSuccessor,
   ) {
-    super(abstractElements, parentInstance, previousAbstractSiblingCount);
+    super(abstractElements, parentInstance, getSuccessor);
     this.props = abstractElements;
     this.addChildren(abstractElements);
-  }
-
-  /**
-   * calculates the previous siblinglength, array is not its own parent, children are dependent of previousAbstractSiblingCount
-   */
-  public getPreviousSiblingsForChildren() {
-    return this.previousAbstractSiblingCount();
   }
 
   public reconcile(newAbstractElements: PlusnewAbstractElement[]) {
     reconcile(newAbstractElements, this);
     return this;
+  }
+
+  public getChildrenSuccessor() {
+    return () => this.getSuccessor();
   }
 }

--- a/src/instances/types/Array/Instance.ts
+++ b/src/instances/types/Array/Instance.ts
@@ -25,6 +25,6 @@ export default class ArrayInstance extends ChildrenInstance {
   }
 
   public getChildrenSuccessor() {
-    return () => this.getSuccessor();
+    return this.getSuccessor();
   }
 }

--- a/src/instances/types/Array/Instance.ts
+++ b/src/instances/types/Array/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance, { getSuccessor } from '../Instance';
+import Instance, { getPredeccessor } from '../Instance';
 import ChildrenInstance from '../ChildrenInstance';
 import PlusnewAbstractElement from '../../../PlusnewAbstractElement';
 import reconcile from './reconcile';
@@ -12,9 +12,9 @@ export default class ArrayInstance extends ChildrenInstance {
   constructor(
     abstractElements: (PlusnewAbstractElement)[],
     parentInstance: Instance,
-    getSuccessor: getSuccessor,
+    getPredecessor: getPredeccessor,
   ) {
-    super(abstractElements, parentInstance, getSuccessor);
+    super(abstractElements, parentInstance, getPredecessor);
     this.props = abstractElements;
     this.addChildren(abstractElements);
   }
@@ -24,7 +24,7 @@ export default class ArrayInstance extends ChildrenInstance {
     return this;
   }
 
-  public getChildrenSuccessor() {
-    return this.getSuccessor();
+  public getChildrenPredeccessor() {
+    return this.getPredecessor();
   }
 }

--- a/src/instances/types/Array/reconcile.ts
+++ b/src/instances/types/Array/reconcile.ts
@@ -39,7 +39,6 @@ export default function (newAbstractElements: PlusnewAbstractElement[], instance
   }
 
   for (let i = 0; i < newAbstractElements.length; i += 1) {
-    if(window.foo) debugger;
     const newAbstractElement = newAbstractElements[i];
 
     const getPredecessor = instance.getLastIntrinsicElementOf.bind(instance, i - 1);

--- a/src/instances/types/Array/reconcile.ts
+++ b/src/instances/types/Array/reconcile.ts
@@ -41,20 +41,20 @@ export default function (newAbstractElements: PlusnewAbstractElement[], instance
 
   for (let i = 0; i < newAbstractElements.length; i += 1) {
     const newAbstractElement = newAbstractElements[i];
-    const previousLength = instance.getPreviousLength.bind(instance, i);
+    const getSuccessor = instance.getSuccessorOf.bind(instance, i);
 
     if (
       i < instance.rendered.length &&
       reconciler.isSameAbstractElement(newAbstractElement, instance.rendered[i])
     ) {
-      instance.rendered[i].previousAbstractSiblingCount = previousLength;
+      instance.rendered[i].getSuccessor = getSuccessor;
       reconciler.update(newAbstractElement, instance.rendered[i]);
     } else {
       const oldIndex = indexOf(instance, newAbstractElement, i);
       if (oldIndex === NOT_FOUND) {
-        instance.rendered.splice(i, 0, factory(newAbstractElement, instance, previousLength));
+        instance.rendered.splice(i, 0, factory(newAbstractElement, instance, getSuccessor));
       } else {
-        instance.rendered[oldIndex].previousAbstractSiblingCount = previousLength;
+        instance.rendered[oldIndex].getSuccessor = getSuccessor;
         // instance should move to the new position
         instance.rendered.splice(i, 0, instance.rendered[oldIndex]);
 
@@ -62,7 +62,7 @@ export default function (newAbstractElements: PlusnewAbstractElement[], instance
         // it needs the +1 offset, because a line before it just got inserted and the oldIndex is one after it was before
         instance.rendered.splice(oldIndex + 1, 1);
 
-        instance.rendered[i].move(previousLength());
+        instance.rendered[i].move(getSuccessor());
         reconciler.update(newAbstractElement, instance.rendered[i]);
       }
     }

--- a/src/instances/types/Array/reconcile.ts
+++ b/src/instances/types/Array/reconcile.ts
@@ -38,6 +38,7 @@ export default function (newAbstractElements: PlusnewAbstractElement[], instance
     }
   }
 
+  // @TODO newabstractelements needs to go from last to 0
   for (let i = 0; i < newAbstractElements.length; i += 1) {
     const newAbstractElement = newAbstractElements[i];
 
@@ -62,15 +63,13 @@ export default function (newAbstractElements: PlusnewAbstractElement[], instance
         const moveInstance = instance.rendered[oldIndex];
         moveInstance.getSuccessor = getSuccessor;
 
-        // first the instance needs to removed, to be moved
-        // if it doesn't get removed, the getSuccessor might run endlessly, if it doesn't have intrinsic elements inside
-        instance.rendered.splice(oldIndex, 1);
+        // instance should move to the new position
+        instance.rendered.splice(i, 0, instance.rendered[oldIndex]);
+        // remove old instance
+        // it needs the +1 offset, because a line before it just got inserted and the oldIndex is one after it was before
+        instance.rendered.splice(oldIndex + 1, 1);
 
         instance.rendered[i].move(getSuccessor());
-
-        // instance should move to the new position
-        // remove old instance
-        instance.rendered.splice(i, 0, moveInstance);
 
         reconciler.update(newAbstractElement, instance.rendered[i]);
       }

--- a/src/instances/types/Array/reconcile.ts
+++ b/src/instances/types/Array/reconcile.ts
@@ -38,30 +38,27 @@ export default function (newAbstractElements: PlusnewAbstractElement[], instance
     }
   }
 
-  // @TODO newabstractelements needs to go from last to 0
   for (let i = 0; i < newAbstractElements.length; i += 1) {
+    if(window.foo) debugger;
     const newAbstractElement = newAbstractElements[i];
 
-    const getSuccessor = instance.getFirstIntrinsicElementOf.bind(instance, i + 1);
+    const getPredecessor = instance.getLastIntrinsicElementOf.bind(instance, i - 1);
 
     if (
       i < instance.rendered.length &&
       reconciler.isSameAbstractElement(newAbstractElement, instance.rendered[i])
     ) {
-      instance.rendered[i].getSuccessor = getSuccessor;
+      instance.rendered[i].getPredecessor = getPredecessor;
 
       reconciler.update(newAbstractElement, instance.rendered[i]);
     } else {
       const oldIndex = indexOf(instance, newAbstractElement, i);
       if (oldIndex === NOT_FOUND) {
-        // temporary is needed, because of the time when factory is executed, the instance is not yet inside the renderer included
-        const temporaryGetSuccessor = instance.getFirstIntrinsicElementOf.bind(instance, i);
-        const newInstance = factory(newAbstractElement, instance, temporaryGetSuccessor);
-        newInstance.getSuccessor = getSuccessor;
+        const newInstance = factory(newAbstractElement, instance, getPredecessor);
         instance.rendered.splice(i, 0, newInstance);
       } else {
         const moveInstance = instance.rendered[oldIndex];
-        moveInstance.getSuccessor = getSuccessor;
+        moveInstance.getPredecessor = getPredecessor;
 
         // instance should move to the new position
         instance.rendered.splice(i, 0, instance.rendered[oldIndex]);
@@ -69,7 +66,7 @@ export default function (newAbstractElements: PlusnewAbstractElement[], instance
         // it needs the +1 offset, because a line before it just got inserted and the oldIndex is one after it was before
         instance.rendered.splice(oldIndex + 1, 1);
 
-        instance.rendered[i].move(getSuccessor());
+        instance.rendered[i].move(getPredecessor());
 
         reconciler.update(newAbstractElement, instance.rendered[i]);
       }

--- a/src/instances/types/ChildrenInstance.ts
+++ b/src/instances/types/ChildrenInstance.ts
@@ -1,5 +1,5 @@
 import { ApplicationElement } from '../../interfaces/component';
-import Instance, { getSuccessor, successor } from './Instance';
+import Instance, { getPredeccessor, predecessor } from './Instance';
 import factory from '../factory';
 
 export default abstract class ChildrenInstance extends Instance {
@@ -8,43 +8,43 @@ export default abstract class ChildrenInstance extends Instance {
   constructor(
     abstractElement: ApplicationElement,
     parentInstance: Instance,
-    getSuccessor: getSuccessor,
+    getPredecessor: getPredeccessor,
   ) {
-    super(abstractElement, parentInstance, getSuccessor);
+    super(abstractElement, parentInstance, getPredecessor);
 
     this.rendered = [];
   }
 
-  abstract getChildrenSuccessor(): successor;
+  abstract getChildrenPredeccessor(): predecessor;
 
   public addChildren(children: ApplicationElement[]) {
     for (let i = 0; i < children.length; i += 1) {
-      this.rendered.push(factory(children[i], this, this.getFirstIntrinsicElementOf.bind(this, i + 1)));
+      this.rendered.push(factory(children[i], this, this.getLastIntrinsicElementOf.bind(this, i - 1)));
     }
 
     return this;
   }
 
-  public getFirstIntrinsicElement() {
-    return this.getFirstIntrinsicElementOf(0);
+  public getLastIntrinsicElement() {
+    return this.getLastIntrinsicElementOf(this.rendered.length - 1);
   }
 
-  public getFirstIntrinsicElementOf(index: number) {
-    for (let i = index; i < this.rendered.length; i += 1) {
-      const successorElement =  this.rendered[i].getFirstIntrinsicElement();
-      if (successorElement !== null) {
-        return successorElement;
+  public getLastIntrinsicElementOf(index: number) {
+    for (let i = index; i >= 0 && i < this.rendered.length; i -= 1) {
+      const predeccessorElement =  this.rendered[i].getLastIntrinsicElement();
+      if (predeccessorElement !== null) {
+        return predeccessorElement;
       }
     }
-    return this.getChildrenSuccessor();
+    return this.getChildrenPredeccessor();
   }
 
   /**
    * moves the children to another dom position
    */
-  public move(successor: successor) {
+  public move(predecessor: predecessor) {
     for (let i = 0; i < this.rendered.length; i += 1) {
-      this.rendered[i].move(successor);
+      this.rendered[i].move(predecessor);
     }
 
     return this;

--- a/src/instances/types/ChildrenInstance.ts
+++ b/src/instances/types/ChildrenInstance.ts
@@ -15,36 +15,36 @@ export default abstract class ChildrenInstance extends Instance {
     this.rendered = [];
   }
 
-  abstract getChildrenSuccessor(): getSuccessor;
+  abstract getChildrenSuccessor(): successor;
 
   public addChildren(children: ApplicationElement[]) {
     for (let i = 0; i < children.length; i += 1) {
-      this.rendered.push(factory(children[i], this, this.getChildrenSuccessor()));
+      this.rendered.push(factory(children[i], this, this.getFirstIntrinsicElementOf.bind(this, i + 1)));
     }
 
     return this;
   }
 
-  public getSuccessorOf(index: number) {
-    for (let successor = index + 1; successor < this.rendered.length; successor += 1) {
-      const successorElement =  this.rendered[successor].getFirstIntrinsicElement();
+  public getFirstIntrinsicElement() {
+    return this.getFirstIntrinsicElementOf(0);
+  }
+
+  public getFirstIntrinsicElementOf(index: number) {
+    for (let i = index; i < this.rendered.length; i += 1) {
+      const successorElement =  this.rendered[i].getFirstIntrinsicElement();
       if (successorElement !== null) {
         return successorElement;
       }
     }
-    return this.getSuccessor();
-  }
-
-  public getFirstIntrinsicElement() {
-    return this.getSuccessorOf(0);
+    return this.getChildrenSuccessor();
   }
 
   /**
    * moves the children to another dom position
    */
   public move(successor: successor) {
-    for (let i = this.rendered.length; i > 0; i -= 1) {
-      this.rendered[i - 1].move(successor);
+    for (let i = 0; i < this.rendered.length; i += 1) {
+      this.rendered[i].move(successor);
     }
 
     return this;

--- a/src/instances/types/ChildrenInstance.ts
+++ b/src/instances/types/ChildrenInstance.ts
@@ -43,8 +43,8 @@ export default abstract class ChildrenInstance extends Instance {
    * moves the children to another dom position
    */
   public move(predecessor: predecessor) {
-    for (let i = 0; i < this.rendered.length; i += 1) {
-      this.rendered[i].move(predecessor);
+    for (let i = this.rendered.length; i > 0; i -= 1) {
+      this.rendered[i - 1].move(predecessor);
     }
 
     return this;

--- a/src/instances/types/Component/Instance.ts
+++ b/src/instances/types/Component/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance, { getSuccessor, successor } from '../Instance';
+import Instance, { getPredeccessor, predecessor } from '../Instance';
 import factory from '../../factory';
 import reconcile, { shouldUpdate } from './reconcile';
 import PlusnewAbstractElement from '../../../PlusnewAbstractElement';
@@ -20,9 +20,9 @@ export default class ComponentInstance extends Instance {
   constructor(
     abstractElement: PlusnewAbstractElement,
     parentInstance: Instance,
-    getSuccessor: getSuccessor,
+    getPredecessor: getPredeccessor,
   ) {
-    super(abstractElement, parentInstance, getSuccessor);
+    super(abstractElement, parentInstance, getPredecessor);
 
     this.type = abstractElement.type;
     this.props = abstractElement.props;
@@ -65,13 +65,13 @@ export default class ComponentInstance extends Instance {
         .registerDependencies(constructor(this.props, this.options));
 
     const abstractChildren = this.render(this.props, this.dependencies, this.options);
-    this.rendered = factory(abstractChildren, this, () => this.getSuccessor());
+    this.rendered = factory(abstractChildren, this, () => this.getPredecessor());
 
     return this;
   }
 
-  public getFirstIntrinsicElement() {
-    return this.rendered.getFirstIntrinsicElement();
+  public getLastIntrinsicElement() {
+    return this.rendered.getLastIntrinsicElement();
   }
 
   /**
@@ -93,8 +93,8 @@ export default class ComponentInstance extends Instance {
   /**
    * moves the children to another dom position
    */
-  public move(successor: successor) {
-    this.rendered.move(successor);
+  public move(predecessor: predecessor) {
+    this.rendered.move(predecessor);
 
     return this;
   }

--- a/src/instances/types/Component/Instance.ts
+++ b/src/instances/types/Component/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance from '../Instance';
+import Instance, { getSuccessor, successor } from '../Instance';
 import factory from '../../factory';
 import reconcile, { shouldUpdate } from './reconcile';
 import PlusnewAbstractElement from '../../../PlusnewAbstractElement';
@@ -20,9 +20,9 @@ export default class ComponentInstance extends Instance {
   constructor(
     abstractElement: PlusnewAbstractElement,
     parentInstance: Instance,
-    previousAbstractSiblingCount: () => number,
+    getSuccessor: getSuccessor,
   ) {
-    super(abstractElement, parentInstance, previousAbstractSiblingCount);
+    super(abstractElement, parentInstance, getSuccessor);
 
     this.type = abstractElement.type;
     this.props = abstractElement.props;
@@ -65,9 +65,13 @@ export default class ComponentInstance extends Instance {
         .registerDependencies(constructor(this.props, this.options));
 
     const abstractChildren = this.render(this.props, this.dependencies, this.options);
-    this.rendered = factory(abstractChildren, this, () => this.previousAbstractSiblingCount());
+    this.rendered = factory(abstractChildren, this, () => this.getSuccessor());
 
     return this;
+  }
+
+  public getFirstIntrinsicElement() {
+    return this.rendered.getFirstIntrinsicElement();
   }
 
   /**
@@ -89,14 +93,10 @@ export default class ComponentInstance extends Instance {
   /**
    * moves the children to another dom position
    */
-  public move(position: number) {
-    this.rendered.move(position);
+  public move(successor: successor) {
+    this.rendered.move(successor);
 
     return this;
-  }
-
-  public getLength() {
-    return this.rendered.getLength();
   }
 
   /**

--- a/src/instances/types/Dom/Instance.ts
+++ b/src/instances/types/Dom/Instance.ts
@@ -1,6 +1,6 @@
 import PlusnewAbstractElement from 'PlusnewAbstractElement';
 import types from '../types';
-import Instance, { getSuccessor, successor } from '../Instance';
+import Instance, { getPredeccessor, predecessor } from '../Instance';
 import ChildrenInstance from '../ChildrenInstance';
 import { getSpecialNamespace } from '../../../util/namespace';
 import { hasOnchangeEvent, hasInputEvent } from '../../../util/dom';
@@ -22,9 +22,9 @@ export default class DomInstance extends ChildrenInstance {
   constructor(
     abstractElement: PlusnewAbstractElement,
     parentInstance: Instance,
-    successor: getSuccessor,
+    predecessor: getPredeccessor,
   ) {
-    super(abstractElement, parentInstance, successor);
+    super(abstractElement, parentInstance, predecessor);
     this.type = abstractElement.type;
     this.props = abstractElement.props;
     this.setNamespace();
@@ -35,19 +35,19 @@ export default class DomInstance extends ChildrenInstance {
       this.ref = document.createElement(abstractElement.type as string);
     }
 
-    this.setProps()
-        .addChildren(abstractElement.props.children)
-        .setAutofocusIfNeeded()
-        .appendToParent(this.ref, successor())
-        .setOnChangeEvent();
+    this.setProps();
+    this.addChildren(abstractElement.props.children);
+    this.setAutofocusIfNeeded();
+    this.appendToParent(this.ref, predecessor());
+    this.setOnChangeEvent();
   }
 
 
-  public getFirstIntrinsicElement() {
+  public getLastIntrinsicElement() {
     return this.ref;
   }
 
-  public getChildrenSuccessor() {
+  public getChildrenPredeccessor() {
     return null;
   }
 
@@ -197,19 +197,26 @@ export default class DomInstance extends ChildrenInstance {
   /**
    * by the children should add themselfs to our element
    */
-  public appendChild(element: Node, successor: Node | null) {
-    this.ref.insertBefore(element, successor);
-
+  public appendChild(element: Node, predecessor: Node | null) {
+    const parentNode = this.ref as Node;
+    if (predecessor === null) {
+      this.ref.insertBefore(element, parentNode.firstChild);
+    } else {
+      this.ref.insertBefore(element, predecessor.nextSibling);
+    }
     return this;
   }
 
   /**
    * moves the domnode from the parent
    */
-  public move(successor: successor) {
+  public move(predecessor: predecessor) {
     const parentNode = this.ref.parentNode as Node;
-    parentNode.insertBefore(this.ref, successor);
-
+    if (predecessor === null) {
+      parentNode.insertBefore(this.ref, parentNode.firstChild);
+    } else {
+      parentNode.insertBefore(this.ref, predecessor.nextSibling);
+    }
     return this;
   }
 

--- a/src/instances/types/Dom/Instance.ts
+++ b/src/instances/types/Dom/Instance.ts
@@ -198,12 +198,7 @@ export default class DomInstance extends ChildrenInstance {
    * by the children should add themselfs to our element
    */
   public appendChild(element: Node, predecessor: Node | null) {
-    const parentNode = this.ref as Node;
-    if (predecessor === null) {
-      this.ref.insertBefore(element, parentNode.firstChild);
-    } else {
-      this.ref.insertBefore(element, predecessor.nextSibling);
-    }
+    this.insertBefore(this.ref, element, predecessor);
     return this;
   }
 
@@ -211,12 +206,7 @@ export default class DomInstance extends ChildrenInstance {
    * moves the domnode from the parent
    */
   public move(predecessor: predecessor) {
-    const parentNode = this.ref.parentNode as Node;
-    if (predecessor === null) {
-      parentNode.insertBefore(this.ref, parentNode.firstChild);
-    } else {
-      parentNode.insertBefore(this.ref, predecessor.nextSibling);
-    }
+    this.insertBefore(this.ref.parentNode as Node, this.ref, predecessor);
     return this;
   }
 

--- a/src/instances/types/Dom/Instance.ts
+++ b/src/instances/types/Dom/Instance.ts
@@ -48,7 +48,7 @@ export default class DomInstance extends ChildrenInstance {
   }
 
   public getChildrenSuccessor() {
-    return () => null;
+    return null;
   }
 
   private setNamespace() {

--- a/src/instances/types/Dom/reconcile.ts
+++ b/src/instances/types/Dom/reconcile.ts
@@ -15,7 +15,7 @@ export default function (props: props, instance: DomInstance) {
           }
         } else {
           instance.rendered.push(
-            factory(props.children[i], instance, instance.getFirstIntrinsicElementOf.bind(instance, i + 1)),
+            factory(props.children[i], instance, instance.getLastIntrinsicElementOf.bind(instance, i - 1)),
           );
         }
       }

--- a/src/instances/types/Dom/reconcile.ts
+++ b/src/instances/types/Dom/reconcile.ts
@@ -15,7 +15,7 @@ export default function (props: props, instance: DomInstance) {
           }
         } else {
           instance.rendered.push(
-            factory(props.children[i], instance, instance.getPreviousLength.bind(instance, i)),
+            factory(props.children[i], instance, instance.getSuccessorOf.bind(instance, i)),
           );
         }
       }

--- a/src/instances/types/Dom/reconcile.ts
+++ b/src/instances/types/Dom/reconcile.ts
@@ -15,7 +15,7 @@ export default function (props: props, instance: DomInstance) {
           }
         } else {
           instance.rendered.push(
-            factory(props.children[i], instance, instance.getSuccessorOf.bind(instance, i)),
+            factory(props.children[i], instance, instance.getFirstIntrinsicElementOf.bind(instance, i + 1)),
           );
         }
       }

--- a/src/instances/types/Fragment/Instance.ts
+++ b/src/instances/types/Fragment/Instance.ts
@@ -26,6 +26,6 @@ export default class FragmentInstance extends ChildrenInstance {
   }
 
   public getChildrenSuccessor() {
-    return () => this.getSuccessor();
+    return this.getSuccessor();
   }
 }

--- a/src/instances/types/Fragment/Instance.ts
+++ b/src/instances/types/Fragment/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance from '../Instance';
+import Instance, { getSuccessor } from '../Instance';
 import ChildrenInstance from '../ChildrenInstance';
 import PlusnewAbstractElement from '../../../PlusnewAbstractElement';
 import { props } from '../../../interfaces/component';
@@ -13,22 +13,19 @@ export default class FragmentInstance extends ChildrenInstance {
   constructor(
     abstractElement: PlusnewAbstractElement,
     parentInstance: Instance,
-    previousAbstractSiblingCount: () => number,
+    getSuccessor: getSuccessor,
   ) {
-    super(abstractElement, parentInstance, previousAbstractSiblingCount);
+    super(abstractElement, parentInstance, getSuccessor);
     this.props = abstractElement.props;
     this.addChildren(abstractElement.props.children);
-  }
-
-  /**
-   * calculates the previous siblinglength, array is not its own parent, children are dependent of previousAbstractSiblingCount
-   */
-  public getPreviousSiblingsForChildren() {
-    return this.previousAbstractSiblingCount();
   }
 
   public reconcile(newAbstractElement: PlusnewAbstractElement) {
     reconcile(newAbstractElement, this);
     return this;
+  }
+
+  public getChildrenSuccessor() {
+    return () => this.getSuccessor();
   }
 }

--- a/src/instances/types/Fragment/Instance.ts
+++ b/src/instances/types/Fragment/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance, { getSuccessor } from '../Instance';
+import Instance, { getPredeccessor } from '../Instance';
 import ChildrenInstance from '../ChildrenInstance';
 import PlusnewAbstractElement from '../../../PlusnewAbstractElement';
 import { props } from '../../../interfaces/component';
@@ -13,9 +13,9 @@ export default class FragmentInstance extends ChildrenInstance {
   constructor(
     abstractElement: PlusnewAbstractElement,
     parentInstance: Instance,
-    getSuccessor: getSuccessor,
+    getPredecessor: getPredeccessor,
   ) {
-    super(abstractElement, parentInstance, getSuccessor);
+    super(abstractElement, parentInstance, getPredecessor);
     this.props = abstractElement.props;
     this.addChildren(abstractElement.props.children);
   }
@@ -25,7 +25,7 @@ export default class FragmentInstance extends ChildrenInstance {
     return this;
   }
 
-  public getChildrenSuccessor() {
-    return this.getSuccessor();
+  public getChildrenPredeccessor() {
+    return this.getPredecessor();
   }
 }

--- a/src/instances/types/Fragment/reconcile.ts
+++ b/src/instances/types/Fragment/reconcile.ts
@@ -13,7 +13,7 @@ export default function (newAbstractElement: PlusnewAbstractElement, instance: F
       }
     } else {
       instance.rendered.push(
-        factory(newAbstractElement.props.children[i], instance, instance.getFirstIntrinsicElementOf.bind(instance, i + 1)),
+        factory(newAbstractElement.props.children[i], instance, instance.getLastIntrinsicElementOf.bind(instance, i - 1)),
       );
     }
   }

--- a/src/instances/types/Fragment/reconcile.ts
+++ b/src/instances/types/Fragment/reconcile.ts
@@ -13,7 +13,7 @@ export default function (newAbstractElement: PlusnewAbstractElement, instance: F
       }
     } else {
       instance.rendered.push(
-        factory(newAbstractElement.props.children[i], instance, instance.getSuccessorOf.bind(instance, i)),
+        factory(newAbstractElement.props.children[i], instance, instance.getFirstIntrinsicElementOf.bind(instance, i + 1)),
       );
     }
   }

--- a/src/instances/types/Fragment/reconcile.ts
+++ b/src/instances/types/Fragment/reconcile.ts
@@ -13,7 +13,7 @@ export default function (newAbstractElement: PlusnewAbstractElement, instance: F
       }
     } else {
       instance.rendered.push(
-        factory(newAbstractElement.props.children[i], instance, instance.getPreviousLength.bind(instance, i)),
+        factory(newAbstractElement.props.children[i], instance, instance.getSuccessorOf.bind(instance, i)),
       );
     }
   }

--- a/src/instances/types/Instance.ts
+++ b/src/instances/types/Instance.ts
@@ -2,22 +2,25 @@ import { ApplicationElement, props } from '../../interfaces/component';
 import { PlusnewElement } from '../../PlusnewAbstractElement';
 import types from './types';
 
+export type successor = Node | null;
+export type getSuccessor = () => successor;
+
 export default abstract class Instance {
   public nodeType: types;
   public parentInstance?: Instance;
   public type: PlusnewElement;
   public props: ApplicationElement | props;
-  public previousAbstractSiblingCount: () => number;
+  public getSuccessor: getSuccessor;
   public namespace?: string;
   public createChildrenComponents = true;
 
   constructor(
     abstractElement: ApplicationElement,
     parentInstance: Instance | undefined,
-    previousAbstractSiblingCount: () => number,
+    getSuccessor: getSuccessor,
   ) {
     this.parentInstance = parentInstance;
-    this.previousAbstractSiblingCount = previousAbstractSiblingCount;
+    this.getSuccessor = getSuccessor;
     if (this.parentInstance) {
       this.namespace = this.parentInstance.namespace;
       this.createChildrenComponents = this.parentInstance.createChildrenComponents;
@@ -27,11 +30,11 @@ export default abstract class Instance {
   /**
    * appends the given element, to the parentinstance, if existent
    */
-  public appendToParent(element: Node, index: number) {
+  public appendToParent(element: Node, successor: successor) {
     if (this.parentInstance === undefined) {
       throw new Error('Cant append element to not existing parent');
     } else {
-      this.parentInstance.appendChild(element, index);
+      this.parentInstance.appendChild(element, successor);
     }
 
     return this;
@@ -40,25 +43,22 @@ export default abstract class Instance {
   /**
    * makes a insertBefore to the parent
    */
-  public appendChild(element: Node, index: number) {
+  public appendChild(element: Node, successor: successor) {
     if (this.parentInstance === undefined) {
       throw new Error('Couldn\'t add child to parent');
     } else {
-      this.parentInstance.appendChild(element, index);
+      this.parentInstance.appendChild(element, successor);
     }
 
     return this;
   }
 
-  /**
-   * how many dom elements does this instance have
-   */
-  public abstract getLength(): number;
+  public abstract getFirstIntrinsicElement(): Node | null;
 
   /**
    * orders to move itself to another place
    */
-  public abstract move(position: number): Instance;
+  public abstract move(successor: successor): Instance;
 
   /**
    * orders to remove itself from the dom

--- a/src/instances/types/Instance.ts
+++ b/src/instances/types/Instance.ts
@@ -2,25 +2,25 @@ import { ApplicationElement, props } from '../../interfaces/component';
 import { PlusnewElement } from '../../PlusnewAbstractElement';
 import types from './types';
 
-export type successor = Node | null;
-export type getSuccessor = () => successor;
+export type predecessor = Node | null;
+export type getPredeccessor = () => predecessor;
 
 export default abstract class Instance {
   public nodeType: types;
   public parentInstance?: Instance;
   public type: PlusnewElement;
   public props: ApplicationElement | props;
-  public getSuccessor: getSuccessor;
+  public getPredecessor: getPredeccessor;
   public namespace?: string;
   public createChildrenComponents = true;
 
   constructor(
     abstractElement: ApplicationElement,
     parentInstance: Instance | undefined,
-    getSuccessor: getSuccessor,
+    getPredecessor: getPredeccessor,
   ) {
     this.parentInstance = parentInstance;
-    this.getSuccessor = getSuccessor;
+    this.getPredecessor = getPredecessor;
     if (this.parentInstance) {
       this.namespace = this.parentInstance.namespace;
       this.createChildrenComponents = this.parentInstance.createChildrenComponents;
@@ -30,11 +30,11 @@ export default abstract class Instance {
   /**
    * appends the given element, to the parentinstance, if existent
    */
-  public appendToParent(element: Node, successor: successor) {
+  public appendToParent(element: Node, predecessor: predecessor) {
     if (this.parentInstance === undefined) {
       throw new Error('Cant append element to not existing parent');
     } else {
-      this.parentInstance.appendChild(element, successor);
+      this.parentInstance.appendChild(element, predecessor);
     }
 
     return this;
@@ -43,22 +43,22 @@ export default abstract class Instance {
   /**
    * makes a insertBefore to the parent
    */
-  public appendChild(element: Node, successor: successor) {
+  public appendChild(element: Node, predecessor: predecessor) {
     if (this.parentInstance === undefined) {
       throw new Error('Couldn\'t add child to parent');
     } else {
-      this.parentInstance.appendChild(element, successor);
+      this.parentInstance.appendChild(element, predecessor);
     }
 
     return this;
   }
 
-  public abstract getFirstIntrinsicElement(): Node | null;
+  public abstract getLastIntrinsicElement(): Node | null;
 
   /**
    * orders to move itself to another place
    */
-  public abstract move(successor: successor): Instance;
+  public abstract move(predecessor: predecessor): Instance;
 
   /**
    * orders to remove itself from the dom

--- a/src/instances/types/Instance.ts
+++ b/src/instances/types/Instance.ts
@@ -53,6 +53,14 @@ export default abstract class Instance {
     return this;
   }
 
+  public insertBefore(parentNode: Node, target: Node, predecessor: predecessor) {
+    if (predecessor === null) {
+      parentNode.insertBefore(target, parentNode.firstChild);
+    } else {
+      parentNode.insertBefore(target, predecessor.nextSibling);
+    }
+  }
+
   public abstract getLastIntrinsicElement(): Node | null;
 
   /**

--- a/src/instances/types/Placeholder/Instance.ts
+++ b/src/instances/types/Placeholder/Instance.ts
@@ -5,13 +5,10 @@ export default class PlaceHolderInstance extends Instance {
   public nodeType = types.Placeholder;
   public type = types.Fragment;
 
-  /**
-   * the placeholder is not a dom object, that's why it has no length
-   */
-  public getLength() {
-    return 0;
-  }
 
+  public getFirstIntrinsicElement() {
+    return null;
+  }
   /**
    * placeholder has no object, which needs moving
    */

--- a/src/instances/types/Placeholder/Instance.ts
+++ b/src/instances/types/Placeholder/Instance.ts
@@ -6,7 +6,7 @@ export default class PlaceHolderInstance extends Instance {
   public type = types.Fragment;
 
 
-  public getFirstIntrinsicElement() {
+  public getLastIntrinsicElement() {
     return null;
   }
 

--- a/src/instances/types/Placeholder/Instance.ts
+++ b/src/instances/types/Placeholder/Instance.ts
@@ -9,6 +9,7 @@ export default class PlaceHolderInstance extends Instance {
   public getFirstIntrinsicElement() {
     return null;
   }
+
   /**
    * placeholder has no object, which needs moving
    */

--- a/src/instances/types/Root/Instance.ts
+++ b/src/instances/types/Root/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance, { getSuccessor } from '../Instance';
+import Instance, { getPredeccessor } from '../Instance';
 import { ApplicationElement } from '../../../interfaces/component';
 
 type renderOptions = {
@@ -15,10 +15,10 @@ export default class RootInstance extends Instance {
   constructor(
     abstractElement: ApplicationElement,
     parentInstance: Instance | undefined,
-    getSuccessor: getSuccessor,
+    getPredecessor: getPredeccessor,
     options?: renderOptions,
   ) {
-    super(abstractElement, parentInstance, getSuccessor);
+    super(abstractElement, parentInstance, getPredecessor);
 
     if (options) {
       if (options.namespace !== undefined) {
@@ -39,7 +39,7 @@ export default class RootInstance extends Instance {
     return this;
   }
 
-  public getFirstIntrinsicElement() {
+  public getLastIntrinsicElement() {
     return this.ref;
   }
 

--- a/src/instances/types/Root/Instance.ts
+++ b/src/instances/types/Root/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance from '../Instance';
+import Instance, { getSuccessor } from '../Instance';
 import { ApplicationElement } from '../../../interfaces/component';
 
 type renderOptions = {
@@ -15,10 +15,10 @@ export default class RootInstance extends Instance {
   constructor(
     abstractElement: ApplicationElement,
     parentInstance: Instance | undefined,
-    previousAbstractSiblingCount: () => number,
+    getSuccessor: getSuccessor,
     options?: renderOptions,
   ) {
-    super(abstractElement, parentInstance, previousAbstractSiblingCount);
+    super(abstractElement, parentInstance, getSuccessor);
 
     if (options) {
       if (options.namespace !== undefined) {
@@ -39,11 +39,8 @@ export default class RootInstance extends Instance {
     return this;
   }
 
-  /**
-   * Root is no child of nobody, because of that nobody should care how long it is
-   */
-  public getLength(): number {
-    throw new Error('getLength of RootElement is irrelevant');
+  public getFirstIntrinsicElement() {
+    return this.ref;
   }
 
   /**

--- a/src/instances/types/Shallow/Instance.ts
+++ b/src/instances/types/Shallow/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance from '../Instance';
+import Instance, { getSuccessor } from '../Instance';
 import PlusnewAbstractElement from '../../../PlusnewAbstractElement';
 
 export default class ShallowInstance extends Instance {
@@ -8,19 +8,16 @@ export default class ShallowInstance extends Instance {
   constructor(
     abstractElement: PlusnewAbstractElement,
     parentInstance: Instance,
-    previousAbstractSiblingCount: () => number,
+    getSucceessor: getSuccessor,
   ) {
-    super(abstractElement, parentInstance, previousAbstractSiblingCount);
+    super(abstractElement, parentInstance, getSucceessor);
 
     this.type = abstractElement.type;
     this.props = abstractElement.props;
   }
 
- /**
-   * the shallowcomponent is not a dom object, that's why it has no length
-   */
-  public getLength() {
-    return 0;
+  public getFirstIntrinsicElement() {
+    return null;
   }
 
   /**

--- a/src/instances/types/Shallow/Instance.ts
+++ b/src/instances/types/Shallow/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance, { getSuccessor } from '../Instance';
+import Instance, { getPredeccessor } from '../Instance';
 import PlusnewAbstractElement from '../../../PlusnewAbstractElement';
 
 export default class ShallowInstance extends Instance {
@@ -8,15 +8,15 @@ export default class ShallowInstance extends Instance {
   constructor(
     abstractElement: PlusnewAbstractElement,
     parentInstance: Instance,
-    getSucceessor: getSuccessor,
+    getPredecessor: getPredeccessor,
   ) {
-    super(abstractElement, parentInstance, getSucceessor);
+    super(abstractElement, parentInstance, getPredecessor);
 
     this.type = abstractElement.type;
     this.props = abstractElement.props;
   }
 
-  public getFirstIntrinsicElement() {
+  public getLastIntrinsicElement() {
     return null;
   }
 

--- a/src/instances/types/Text/Instance.ts
+++ b/src/instances/types/Text/Instance.ts
@@ -13,6 +13,7 @@ export default class TextInstance extends Instance {
 
     this.props = abstractElement;
     this.ref = document.createTextNode(abstractElement);
+
     this.appendToParent(this.ref, getSuccessor());
   }
 

--- a/src/instances/types/Text/Instance.ts
+++ b/src/instances/types/Text/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance from '../Instance';
+import Instance, { getSuccessor, successor } from '../Instance';
 import reconcile from './reconcile';
 
 export default class TextInstance extends Instance {
@@ -8,18 +8,16 @@ export default class TextInstance extends Instance {
   public props: string;
   public ref: Text;
 
-  constructor(abstractElement: string, parentInstance: Instance, previousAbstractSiblingCount: () => number) {
-    super(abstractElement, parentInstance, previousAbstractSiblingCount);
+  constructor(abstractElement: string, parentInstance: Instance, getSuccessor: getSuccessor) {
+    super(abstractElement, parentInstance, getSuccessor);
 
     this.props = abstractElement;
     this.ref = document.createTextNode(abstractElement);
-    this.appendToParent(this.ref, previousAbstractSiblingCount());
+    this.appendToParent(this.ref, getSuccessor());
   }
-  /**
-   * textnode is always a length of one
-   */
-  public getLength() {
-    return 1;
+
+  public getFirstIntrinsicElement() {
+    return this.ref;
   }
 
   public setText(abstractElement: string) {
@@ -31,9 +29,9 @@ export default class TextInstance extends Instance {
   /**
    * moves this textnode inside the dom
    */
-  public move(position: number) {
+  public move(successor: successor) {
     const parentNode = this.ref.parentNode as Node;
-    parentNode.insertBefore(this.ref, parentNode.childNodes[position]);
+    parentNode.insertBefore(this.ref, successor);
 
     return this;
   }

--- a/src/instances/types/Text/Instance.ts
+++ b/src/instances/types/Text/Instance.ts
@@ -1,5 +1,5 @@
 import types from '../types';
-import Instance, { getSuccessor, successor } from '../Instance';
+import Instance, { getPredeccessor, predecessor } from '../Instance';
 import reconcile from './reconcile';
 
 export default class TextInstance extends Instance {
@@ -8,16 +8,16 @@ export default class TextInstance extends Instance {
   public props: string;
   public ref: Text;
 
-  constructor(abstractElement: string, parentInstance: Instance, getSuccessor: getSuccessor) {
-    super(abstractElement, parentInstance, getSuccessor);
+  constructor(abstractElement: string, parentInstance: Instance, getPredecessor: getPredeccessor) {
+    super(abstractElement, parentInstance, getPredecessor);
 
     this.props = abstractElement;
     this.ref = document.createTextNode(abstractElement);
 
-    this.appendToParent(this.ref, getSuccessor());
+    this.appendToParent(this.ref, getPredecessor());
   }
 
-  public getFirstIntrinsicElement() {
+  public getLastIntrinsicElement() {
     return this.ref;
   }
 
@@ -30,10 +30,13 @@ export default class TextInstance extends Instance {
   /**
    * moves this textnode inside the dom
    */
-  public move(successor: successor) {
+  public move(predecessor: predecessor) {
     const parentNode = this.ref.parentNode as Node;
-    parentNode.insertBefore(this.ref, successor);
-
+    if (predecessor === null) {
+      parentNode.insertBefore(this.ref, parentNode.firstChild);
+    } else {
+      parentNode.insertBefore(this.ref, predecessor.nextSibling);
+    }
     return this;
   }
 

--- a/src/instances/types/Text/Instance.ts
+++ b/src/instances/types/Text/Instance.ts
@@ -31,12 +31,7 @@ export default class TextInstance extends Instance {
    * moves this textnode inside the dom
    */
   public move(predecessor: predecessor) {
-    const parentNode = this.ref.parentNode as Node;
-    if (predecessor === null) {
-      parentNode.insertBefore(this.ref, parentNode.firstChild);
-    } else {
-      parentNode.insertBefore(this.ref, predecessor.nextSibling);
-    }
+    this.insertBefore(this.ref.parentNode as Node, this.ref, predecessor);
     return this;
   }
 

--- a/test/integration/Instances/abstract.spec.tsx
+++ b/test/integration/Instances/abstract.spec.tsx
@@ -6,7 +6,7 @@ describe('Does the root-instance behave correctly', () => {
 
   beforeEach(() => {
     class TestInstance extends Abstract {
-      getFirstIntrinsicElement() {
+      getLastIntrinsicElement() {
         return null;
       }
       move() {

--- a/test/integration/Instances/abstract.spec.tsx
+++ b/test/integration/Instances/abstract.spec.tsx
@@ -6,8 +6,8 @@ describe('Does the root-instance behave correctly', () => {
 
   beforeEach(() => {
     class TestInstance extends Abstract {
-      getLength() {
-        return 0;
+      getFirstIntrinsicElement() {
+        return null;
       }
       move() {
         return this;
@@ -20,16 +20,16 @@ describe('Does the root-instance behave correctly', () => {
       }
     }
 
-    abstract = new TestInstance(<div />, undefined, () => 0);
+    abstract = new TestInstance(<div />, undefined, () => null);
   });
 
   it('appendToParent should throw exception', () => {
     const element = document.createElement('div');
-    expect(() => abstract.appendToParent(element, 0)).toThrow(new Error('Cant append element to not existing parent'));
+    expect(() => abstract.appendToParent(element, null)).toThrow(new Error('Cant append element to not existing parent'));
   });
 
   it('appendChild should throw exception', () => {
     const element = document.createElement('div');
-    expect(() => abstract.appendChild(element, 0)).toThrow(new Error('Couldn\'t add child to parent'));
+    expect(() => abstract.appendChild(element, null)).toThrow(new Error('Couldn\'t add child to parent'));
   });
 });

--- a/test/integration/Instances/root.spec.tsx
+++ b/test/integration/Instances/root.spec.tsx
@@ -5,11 +5,7 @@ describe('Does the root-instance behave correctly', () => {
   let root: Root;
 
   beforeEach(() => {
-    root = new Root(<div />, undefined, () => 0);
-  });
-
-  it('getLength should throw exception', () => {
-    expect(() => root.getLength()).toThrow(new Error('getLength of RootElement is irrelevant'));
+    root = new Root(<div />, undefined, () => null);
   });
 
   it('remove should throw exception', () => {

--- a/test/integration/render/array.spec.tsx
+++ b/test/integration/render/array.spec.tsx
@@ -482,4 +482,124 @@ describe('rendering nested components', () => {
     expect((ul.childNodes[1] as HTMLElement).tagName).toBe('LI');
     expect((ul.childNodes[1] as HTMLElement).innerHTML).toBe('third');
   });
+
+  it('ordering with empty elements in between', () => {
+    const NestedComponent = component(
+      'NestedComponent',
+      () => ({ local }),
+      (props: {}, { local }) => <></>,
+    );
+
+    const list: plusnew.JSX.Element[] = [
+      <span key={0} />,
+      <NestedComponent key={1} />,
+      <div key={2} />,
+    ];
+
+    const local = store(list, (state, action: typeof list) => action);
+
+    const MainComponent = component(
+      'MainComponent',
+      () => ({ local }),
+      (props: {}, { local }) => (
+        <ul>
+          {local.state.map(item => item)}
+        </ul>
+      ),
+    );
+
+    plusnew.render(<MainComponent />, container);
+
+    const ul = container.childNodes[0];
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+    expect((ul.childNodes[1] as HTMLElement).tagName).toBe('DIV');
+
+    local.dispatch([
+      <div key={2} />,
+      <NestedComponent key={1} />,
+      <span key={0} />,
+    ]);
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('DIV');
+    expect((ul.childNodes[1] as HTMLElement).tagName).toBe('SPAN');
+  });
+
+  it('ordering with empty elements on end', () => {
+    const NestedComponent = component(
+      'NestedComponent',
+      () => ({ local }),
+      (props: {}, { local }) => <></>,
+    );
+
+    const list: plusnew.JSX.Element[] = [
+      <NestedComponent key={1} />,
+      <span key={0} />,
+    ];
+
+    const local = store(list, (state, action: typeof list) => action);
+
+    const MainComponent = component(
+      'MainComponent',
+      () => ({ local }),
+      (props: {}, { local }) => (
+        <ul>
+          {local.state.map(item => item)}
+        </ul>
+      ),
+    );
+
+    plusnew.render(<MainComponent />, container);
+
+    const ul = container.childNodes[0];
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+
+    window.foo = true;
+    local.dispatch([
+      <span key={0} />,
+      <NestedComponent key={1} />,
+    ]);
+    window.foo = false;
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+  });
+
+  it('ordering with empty elements on beginning', () => {
+    const NestedComponent = component(
+      'NestedComponent',
+      () => ({ local }),
+      (props: {}, { local }) => <></>,
+    );
+
+    const list: plusnew.JSX.Element[] = [
+      <span key={0} />,
+      <NestedComponent key={1} />,
+    ];
+
+    const local = store(list, (state, action: typeof list) => action);
+
+    const MainComponent = component(
+      'MainComponent',
+      () => ({ local }),
+      (props: {}, { local }) => (
+        <ul>
+          {local.state.map(item => item)}
+        </ul>
+      ),
+    );
+
+    plusnew.render(<MainComponent />, container);
+
+    const ul = container.childNodes[0];
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+
+    local.dispatch([
+      <NestedComponent key={1} />,
+      <span key={0} />,
+    ]);
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+  });
 });

--- a/test/integration/render/array.spec.tsx
+++ b/test/integration/render/array.spec.tsx
@@ -15,7 +15,7 @@ describe('rendering nested components', () => {
     moveSpy = spyOn(HTMLElement.prototype, 'insertBefore').and.callThrough();
   });
 
-  it('does a initial list work, with pushing values', () => {
+  it('does a initial list work, with pushing values with placeholder', () => {
     const Component = component(
       'Component',
       () => ({ local: local() }),
@@ -34,7 +34,7 @@ describe('rendering nested components', () => {
     });
   });
 
-  it('does a initial list work, appended li', () => {
+  it('does a initial list work, appended li with placeholder', () => {
     const list = ['first', 'second', 'third'];
     const Component = component(
       'Component',
@@ -487,7 +487,7 @@ describe('rendering nested components', () => {
     const NestedComponent = component(
       'NestedComponent',
       () => ({ local }),
-      (props: {}, { local }) => <></>,
+      (props: {}, { local }) => false as any,
     );
 
     const list: plusnew.JSX.Element[] = [
@@ -555,12 +555,10 @@ describe('rendering nested components', () => {
 
     expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
 
-    window.foo = true;
     local.dispatch([
       <span key={0} />,
       <NestedComponent key={1} />,
     ]);
-    window.foo = false;
 
     expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
   });
@@ -601,5 +599,252 @@ describe('rendering nested components', () => {
     ]);
 
     expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+  });
+
+
+  it('ordering with empty elements in between with placeholder', () => {
+    const NestedComponent = component(
+      'NestedComponent',
+      () => ({ local }),
+      (props: {}, { local }) => false as any,
+    );
+
+    const list: plusnew.JSX.Element[] = [
+      <span key={0} />,
+      <NestedComponent key={1} />,
+      <div key={2} />,
+    ];
+
+    const local = store(list, (state, action: typeof list) => action);
+
+    const MainComponent = component(
+      'MainComponent',
+      () => ({ local }),
+      (props: {}, { local }) => (
+        <ul>
+          {local.state.map(item => item)}
+        </ul>
+      ),
+    );
+
+    plusnew.render(<MainComponent />, container);
+
+    const ul = container.childNodes[0];
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+    expect((ul.childNodes[1] as HTMLElement).tagName).toBe('DIV');
+
+    local.dispatch([
+      <div key={2} />,
+      <NestedComponent key={1} />,
+      <span key={0} />,
+    ]);
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('DIV');
+    expect((ul.childNodes[1] as HTMLElement).tagName).toBe('SPAN');
+  });
+
+  it('ordering with empty elements on end with placeholder', () => {
+    const NestedComponent = component(
+      'NestedComponent',
+      () => ({ local }),
+      (props: {}, { local }) => false as any,
+    );
+
+    const list: plusnew.JSX.Element[] = [
+      <NestedComponent key={1} />,
+      <span key={0} />,
+    ];
+
+    const local = store(list, (state, action: typeof list) => action);
+
+    const MainComponent = component(
+      'MainComponent',
+      () => ({ local }),
+      (props: {}, { local }) => (
+        <ul>
+          {local.state.map(item => item)}
+        </ul>
+      ),
+    );
+
+    plusnew.render(<MainComponent />, container);
+
+    const ul = container.childNodes[0];
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+
+    local.dispatch([
+      <span key={0} />,
+      <NestedComponent key={1} />,
+    ]);
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+  });
+
+  it('ordering with empty elements on beginning with placeholder', () => {
+    const NestedComponent = component(
+      'NestedComponent',
+      () => ({ local }),
+      (props: {}, { local }) => false as any,
+    );
+
+    const list: plusnew.JSX.Element[] = [
+      <span key={0} />,
+      <NestedComponent key={1} />,
+    ];
+
+    const local = store(list, (state, action: typeof list) => action);
+
+    const MainComponent = component(
+      'MainComponent',
+      () => ({ local }),
+      (props: {}, { local }) => (
+        <ul>
+          {local.state.map(item => item)}
+        </ul>
+      ),
+    );
+
+    plusnew.render(<MainComponent />, container);
+
+    const ul = container.childNodes[0];
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+
+    local.dispatch([
+      <NestedComponent key={1} />,
+      <span key={0} />,
+    ]);
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+  });
+
+  it('ordering with text in between', () => {
+    const NestedComponent = component(
+      'NestedComponent',
+      () => ({ local }),
+      (props: {}, { local }) => 'foo' as any,
+    );
+
+    const list: plusnew.JSX.Element[] = [
+      <span key={0} />,
+      <NestedComponent key={1} />,
+      <div key={2} />,
+    ];
+
+    const local = store(list, (state, action: typeof list) => action);
+
+    const MainComponent = component(
+      'MainComponent',
+      () => ({ local }),
+      (props: {}, { local }) => (
+        <ul>
+          {local.state.map(item => item)}
+        </ul>
+      ),
+    );
+
+    plusnew.render(<MainComponent />, container);
+
+    const ul = container.childNodes[0];
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+    expect((ul.childNodes[1] as Text).textContent).toBe('foo');
+    expect((ul.childNodes[2] as HTMLElement).tagName).toBe('DIV');
+
+    window.foo = true;
+
+    local.dispatch([
+      <div key={2} />,
+      <NestedComponent key={1} />,
+      <span key={0} />,
+    ]);
+
+    window.foo = false;
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('DIV');
+    expect((ul.childNodes[1] as Text).textContent).toBe('foo');
+    expect((ul.childNodes[2] as HTMLElement).tagName).toBe('SPAN');
+  });
+
+  it('ordering with text on end', () => {
+    const NestedComponent = component(
+      'NestedComponent',
+      () => ({ local }),
+      (props: {}, { local }) => 'foo' as any,
+    );
+
+    const list: plusnew.JSX.Element[] = [
+      <NestedComponent key={1} />,
+      <span key={0} />,
+    ];
+
+    const local = store(list, (state, action: typeof list) => action);
+
+    const MainComponent = component(
+      'MainComponent',
+      () => ({ local }),
+      (props: {}, { local }) => (
+        <ul>
+          {local.state.map(item => item)}
+        </ul>
+      ),
+    );
+
+    plusnew.render(<MainComponent />, container);
+
+    const ul = container.childNodes[0];
+
+    expect((ul.childNodes[0] as Text).textContent).toBe('foo');
+    expect((ul.childNodes[1] as HTMLElement).tagName).toBe('SPAN');
+
+    local.dispatch([
+      <span key={0} />,
+      <NestedComponent key={1} />,
+    ]);
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+    expect((ul.childNodes[1] as Text).textContent).toBe('foo');
+  });
+
+  it('ordering with text on beginning', () => {
+    const NestedComponent = component(
+      'NestedComponent',
+      () => ({ local }),
+      (props: {}, { local }) => 'foo' as any,
+    );
+
+    const list: plusnew.JSX.Element[] = [
+      <span key={0} />,
+      <NestedComponent key={1} />,
+    ];
+
+    const local = store(list, (state, action: typeof list) => action);
+
+    const MainComponent = component(
+      'MainComponent',
+      () => ({ local }),
+      (props: {}, { local }) => (
+        <ul>
+          {local.state.map(item => item)}
+        </ul>
+      ),
+    );
+
+    plusnew.render(<MainComponent />, container);
+
+    const ul = container.childNodes[0];
+
+    expect((ul.childNodes[0] as HTMLElement).tagName).toBe('SPAN');
+    expect((ul.childNodes[1] as Text).textContent).toBe('foo');
+
+    local.dispatch([
+      <NestedComponent key={1} />,
+      <span key={0} />,
+    ]);
+
+    expect((ul.childNodes[0] as Text).textContent).toBe('foo');
+    expect((ul.childNodes[1] as HTMLElement).tagName).toBe('SPAN');
   });
 });

--- a/test/integration/render/array.spec.tsx
+++ b/test/integration/render/array.spec.tsx
@@ -82,6 +82,7 @@ describe('rendering nested components', () => {
     expect(ul.childNodes.length).toBe(0);
 
     dependencies.local.dispatch(list);
+
     expect(ul.childNodes.length).toBe(list.length);
 
     ul.childNodes.forEach((li: Node, index) => {
@@ -233,7 +234,9 @@ describe('rendering nested components', () => {
       { key: 4, value: 'zero' },
     ];
 
+    window.foo = true;
     dependencies.local.dispatch(newList);
+    window.foo = true;
 
     expect(span.childNodes.length).toBe(newList.length * 2);
 
@@ -753,15 +756,11 @@ describe('rendering nested components', () => {
     expect((ul.childNodes[1] as Text).textContent).toBe('foo');
     expect((ul.childNodes[2] as HTMLElement).tagName).toBe('DIV');
 
-    window.foo = true;
-
     local.dispatch([
       <div key={2} />,
       <NestedComponent key={1} />,
       <span key={0} />,
     ]);
-
-    window.foo = false;
 
     expect((ul.childNodes[0] as HTMLElement).tagName).toBe('DIV');
     expect((ul.childNodes[1] as Text).textContent).toBe('foo');

--- a/test/integration/render/array.spec.tsx
+++ b/test/integration/render/array.spec.tsx
@@ -234,9 +234,7 @@ describe('rendering nested components', () => {
       { key: 4, value: 'zero' },
     ];
 
-    window.foo = true;
     dependencies.local.dispatch(newList);
-    window.foo = true;
 
     expect(span.childNodes.length).toBe(newList.length * 2);
 

--- a/test/integration/render/fragments.spec.tsx
+++ b/test/integration/render/fragments.spec.tsx
@@ -34,7 +34,7 @@ describe('fragments', () => {
     const list = store([{ key: 1, value: 'one' }], (state, action: entity[]) => action);
 
     const PartialComponent = component(
-      'Component',
+      'PartialComponent',
       () => ({}),
       (props: {value: string}) =>
         <>
@@ -43,7 +43,7 @@ describe('fragments', () => {
         </>,
     );
     const MainComponent = component(
-      'Component',
+      'MainComponent',
       () => ({ list }),
       () =>
         <div>

--- a/test/unit/factory/factory.spec.tsx
+++ b/test/unit/factory/factory.spec.tsx
@@ -14,7 +14,7 @@ describe('isSameAbstractElementType()', () => {
   });
   it('unknown element', () => {
     expect(() => {
-      factory('string', 'another string' as any, () => 0);
+      factory('string', 'another string' as any, () => null);
     }).toThrow(new Error('Factory couldn\'t create unknown element type'));
   });
 });

--- a/test/unit/instances/root.spec.ts
+++ b/test/unit/instances/root.spec.ts
@@ -16,6 +16,6 @@ describe('root', () => {
   it('getFirstIntrinsicElement', () => {
     const instance = new Instance(true, undefined, () => null, {});
     instance.ref = document.createElement('div');
-    expect(instance.getFirstIntrinsicElement()).toBe(instance.ref);
+    expect(instance.getLastIntrinsicElement()).toBe(instance.ref);
   });
 });

--- a/test/unit/instances/root.spec.ts
+++ b/test/unit/instances/root.spec.ts
@@ -7,9 +7,15 @@ describe('root', () => {
     }).toThrow(new Error('The root element can\'t move itself'));
   });
 
-  it('move', () => {
+  it('reconcile', () => {
     expect(() => {
       Instance.prototype.reconcile(false);
     }).toThrow(new Error('The root element can\'t reconcile itself'));
+  });
+
+  it('getFirstIntrinsicElement', () => {
+    const instance = new Instance(true, undefined, () => null, {});
+    instance.ref = document.createElement('div');
+    expect(instance.getFirstIntrinsicElement()).toBe(instance.ref);
   });
 });

--- a/test/unit/reconciler/reconciler.spec.tsx
+++ b/test/unit/reconciler/reconciler.spec.tsx
@@ -7,10 +7,10 @@ import elementTypeChecker from 'util/elementTypeChecker';
 import { ApplicationElement } from 'interfaces/component';
 
 function createInstance(applicationElement: ApplicationElement) {
-  const wrapper = new RootInstance(true, undefined, () => 0, {});
+  const wrapper = new RootInstance(true, undefined, () => null, {});
   wrapper.ref = document.createElement('div');
 
-  return factory(applicationElement, wrapper, () => 0);
+  return factory(applicationElement, wrapper, () => null);
 }
 describe('checking if reconciler works as expected', () => {
   describe('isSameAbstractElement()', () => {

--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,7 @@
       false
     ],
     "variable-name": false,
-    "align": false
+    "align": false,
+    "cyclomatic-complexity": [true]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5572,9 +5572,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
+typescript@2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
 
 uglify-es@^3.3.4:
   version "3.3.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4613,9 +4613,9 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-redchain@0.5.73:
-  version "0.5.73"
-  resolved "https://registry.yarnpkg.com/redchain/-/redchain-0.5.73.tgz#888a4a156ec42242db360f4464ad4d7fc56ea8cf"
+redchain@0.5.101:
+  version "0.5.101"
+  resolved "https://registry.yarnpkg.com/redchain/-/redchain-0.5.101.tgz#7e34361e7d85435a62b22ed0e70a35cc7f21338d"
 
 redent@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
previously the predecessor index got calculated by every previous instance.
now the previous instance gets asked what its previous dom element is. that's much more efficent.

and it allows to have dom-elements to be existent, without a corresponding instance - which will be needed for deleting elements with animations